### PR TITLE
removed initial call to dump() when watching file

### DIFF
--- a/dumper/file/file.go
+++ b/dumper/file/file.go
@@ -16,15 +16,11 @@ import (
 
 // Dump Dumps "acme.json" file to certificates.
 func Dump(acmeFile string, baseConfig *dumper.BaseConfig) error {
-	err := dump(acmeFile, baseConfig)
-	if err != nil {
-		return err
-	}
-
 	if baseConfig.Watch {
 		return watch(acmeFile, baseConfig)
 	}
-	return nil
+
+	return dump(acmeFile, baseConfig)
 }
 
 func dump(acmeFile string, baseConfig *dumper.BaseConfig) error {


### PR DESCRIPTION
This fix helps post-hook scripts that set permissions: before, permissions would stay broken when the tool is started as no post-hook script would be executed after the initial call to `dump()`. Note that this change matches the behavior in `kv.go`.

@ldez, could you make a new release and corresponding docker image with this fix?