### PR TITLE
doc: Traefik v2 acme.json files require "--version v2" on command line

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,7 @@ docker run ldez/traefik-certs-dumper:<tag_name>
 - [traefik-certs-dumper kv](docs/traefik-certs-dumper_kv.md)
 
 ## Examples
+Note: If you are dumping an acme.json file from Traefik v2, you must add "--version v2" as a command line arg.
 
 ### Simple Dump
 

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,8 @@ docker run ldez/traefik-certs-dumper:<tag_name>
 - [traefik-certs-dumper kv](docs/traefik-certs-dumper_kv.md)
 
 ## Examples
-Note: If you are dumping an acme.json file from Traefik v2, you must add "--version v2" as a command line arg.
+
+**Note:** to dump data from Traefik v2, the CLI flag `--version v2` must be added.
 
 ### Simple Dump
 


### PR DESCRIPTION
Figured I'd do one better than submit an issue to improve the documentation (but only by a little bit).  Hopefully it doesn't come across as presumptuous or rude, and hopefully I put it in an acceptable place in the readme.

I didn't realize I needed to add "--version v2" to the command line for acme.json files created by Traefik v2 until I was looking through docs/traefik-certs-dumper_file.md.  Granted, that's what the docs are for, and the "traefik-certs-dumper.exe file --help" command, which does display that bit.

An additional line in the examples that mentions it would be useful for the hapless new user.