### PR TITLE
docker-compose-traefik-v1.yml: fix indents

### DIFF
--- a/docs/docker-compose-traefik-v1.yml
+++ b/docs/docker-compose-traefik-v1.yml
@@ -29,10 +29,11 @@ services:
     entrypoint: sh -c '
       apk add jq
       ; while ! [ -e /data/acme.json ]
-      || ! [ `jq ".Certificates | length" /data/acme.json` != 0 ]; do
-      sleep 1
+        || ! [ `jq ".Certificates | length" /data/acme.json` != 0 ]; do
+          sleep 1
       ; done
-      && traefik-certs-dumper file --watch --source /data/acme.json --dest /data/certs'
+      && traefik-certs-dumper file --watch
+        --source /data/acme.json --dest /data/certs'
     volumes:
       - ./letsencrypt:/letsencrypt
 


### PR DESCRIPTION
@ldez You've lost the indents:

```diff
-        entrypoint: sh -c '
-            apk add jq
-            ; while ! [ -e /data/acme.json ]
-                || ! [ `jq ".Certificates | length" /data/acme.json` != 0 ]; do
-                    sleep 1
-                ; done
-            && traefik-certs-dumper file --watch 
-                --source /data/acme.json --dest 
+    entrypoint: sh -c '
+      apk add jq
+      ; while ! [ -e /data/acme.json ]
+      || ! [ `jq ".Certificates | length" /data/acme.json` != 0 ]; do
+      sleep 1
+      ; done
+      && traefik-certs-dumper file --watch --source 
```

This part looks weird. No doubt. But should `traefik-certs-dumper` check if the file exists (in `--watch` mode) and has certificates, things would turn out simpler.