### PR TITLE
Add: docker & gh-actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,22 @@
+# Docs: <https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/customizing-dependency-updates>
+
 version: 2
 updates:
 - package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10
+
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10
+
+- package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
Hi,
I've added the docker and the gh-actions ecosystem to the dependabot.yml so we get notified if any updated image tags or actions are available. As you're already using this for the go ecosystem, this would be a nice addition I think