### PR TITLE
docs: adds all counts to one sum

### DIFF
--- a/docs/docker-compose-traefik-v2.yml
+++ b/docs/docker-compose-traefik-v2.yml
@@ -26,7 +26,7 @@ services:
     image: ldez/traefik-certs-dumper:v2.8.3
     entrypoint: sh -c '
       while ! [ -e /data/acme.json ]
-      || ! [ `jq ".[] | .Certificates | length" /data/acme.json` != 0 ]; do
+      || ! [ `jq ".[] | .Certificates | length" /data/acme.json | jq -s "add" ` != 0 ]; do
       sleep 1
       ; done
       && traefik-certs-dumper file --version v2 --watch

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,7 @@ services:
     container_name: traefik-certs-dumper
     entrypoint: sh -c '
       while ! [ -e /data/acme.json ]
-      || ! [ `jq ".[] | .Certificates | length" /data/acme.json` != 0 ]; do
+      || ! [ `jq ".[] | .Certificates | length" /data/acme.json | jq -s "add" ` != 0 ]; do
       sleep 1
       ; done
       && traefik-certs-dumper file --version v2 --watch


### PR DESCRIPTION
If both http-01 and dns-01 challenge are used, the original command returns two values.
```
jq ".[] | .Certificates | length" /data/acme.json
11
1
```
Which results in an error occurring in query.
```
traefik-certs-dumper  | + '[' -e /data/acme.json ]
traefik-certs-dumper  | + jq '.[] | .Certificates | length' /data/acme.json
traefik-certs-dumper  | + '[' 11 1 '!=' 0 ]
traefik-certs-dumper  | sh: 1: unknown operand

```
Therefore, the command is extended so that only one value is passed.
```
traefik-certs-dumper  | + '[' -e /data/acme.json ]
traefik-certs-dumper  | + jq '.[] | .Certificates | length' /data/acme.json
traefik-certs-dumper  | + jq -s add
traefik-certs-dumper  | + '[' 12 '!=' 0 ]
```
